### PR TITLE
Orders changed to use tokens, not updated everywhere

### DIFF
--- a/satchless/contrib/payment/mamona_provider/listeners.py
+++ b/satchless/contrib/payment/mamona_provider/listeners.py
@@ -13,7 +13,7 @@ def payment_status_changed_listener(sender, instance=None, old_status=None, new_
 def return_urls_query_listener(sender, instance=None, urls=None, **kwargs):
     urls['failure'] = urls['paid'] = reverse(
                 'satchless-order-view',
-                kwargs={'order_pk': instance.order.order.pk})
+                kwargs={'order_token': instance.order.order.token})
 
 def order_items_query_listener(sender, instance=None, items=None, **kwargs):
     for item in OrderedItem.objects.filter(delivery_group__order=instance.order.order):

--- a/satchless/order/templates/satchless/order/list.html
+++ b/satchless/order/templates/satchless/order/list.html
@@ -12,7 +12,7 @@
     </thead>
     <tbody>
         {% for order in orders %}
-        {% url satchless-order-view order.pk as order_url %}
+        {% url satchless-order-view order.token as order_url %}
         <tr class="{% cycle odd even %}">
             <td><a href="{{ order_url }}">{{ order.pk }}</a></td>
             <td>{{ order.created|date }} {{ order.created|time }}</td>


### PR DESCRIPTION
Fixed some leftover unfixed artifacts in the payment processing from when orders urls changed from pk to a token.
