### PR TITLE
Getting an image Thumbnail object in the template

### DIFF
--- a/satchless/image/templatetags/satchless_image.py
+++ b/satchless/image/templatetags/satchless_image.py
@@ -1,7 +1,13 @@
 from django import template
 
+from ..models import Thumbnail
+
 register = template.Library()
 
 @register.filter
 def at_size(image, size):
     return image.get_absolute_url(size=size)
+
+@register.filter
+def img_at_size(image, size):
+    return Thumbnail.objects.get_or_create_at_size(image.id,size)


### PR DESCRIPTION
I wasn't sure how best to get the height and width of a thumbnail in the template, so rather than use `at_size` which just fetches the absolute url for a thumbnail, I've added a template tag, `img_at_size` which fetches the Thumbnail object itself. That way it's easy to get the height and width. Is there an established way of doing this that I've missed?

``` python
{% for image in product.images.all %}
    {% with image|img_at_size:'product_main' as tmb %}
    <img src="{{ tmb.image.url }}" alt="{{ image.caption }}" height="{{ tmb.height }}" width="{{ tmb.width }}" />
    {% endwith %}
{% endfor %}
```
