### PR TITLE
Fix cache key for PricingCacheHandler.get_product_price_range

### DIFF
--- a/satchless/contrib/pricing/cache/__init__.py
+++ b/satchless/contrib/pricing/cache/__init__.py
@@ -39,7 +39,9 @@ class PricingCacheHandler(PricingHandler, QueueHandler):
     def get_product_price_range(self, product, currency, price_range, **context):
         # Visit cache for a matching entry first
         from django.core.cache import cache
-        key = 'pricerange:' + self._get_key(**context)
+        key = 'pricerange:' + self._get_key(currency=currency,
+                                            product=product,
+                                            **context)
         price_range = cache.get(key)
         if price_range:
             return price_range

--- a/satchless/contrib/pricing/cache/tests.py
+++ b/satchless/contrib/pricing/cache/tests.py
@@ -22,11 +22,20 @@ class Cache(TestCase):
         self.cached_queue = PricingQueue(PricingCacheHandler(ProductFieldGetter))
         self.non_cached_queue = PricingQueue(ProductFieldGetter)
 
-    def test_price(self):
+    def test_variant_price(self):
         p0 = self.non_cached_queue.get_variant_price(self.parrot_a, None)
         p1 = self.cached_queue.get_variant_price(self.parrot_a, None)
         self.assertEqual(p0, p1)
 
         p0 = self.non_cached_queue.get_variant_price(self.cockatoo_a, None)
         p1 = self.cached_queue.get_variant_price(self.cockatoo_a, None)
+        self.assertEqual(p0, p1)
+
+    def test_product_price_range(self):
+        p0 = self.non_cached_queue.get_product_price_range(self.parrot)
+        p1 = self.cached_queue.get_product_price_range(self.parrot)
+        self.assertEqual(p0, p1)
+
+        p0 = self.non_cached_queue.get_product_price_range(self.cockatoo)
+        p1 = self.cached_queue.get_product_price_range(self.cockatoo)
         self.assertEqual(p0, p1)


### PR DESCRIPTION
When making cache keys for price ranges PricingCacheHandler wasn't passing along the the product & currency, which obviously causes problems.  Added fix and a test.
