### PR TITLE
OrderedItem Subclassing

### DIFF
--- a/satchless/cart/forms.py
+++ b/satchless/cart/forms.py
@@ -31,10 +31,13 @@ class AddToCartForm(forms.Form, QuantityForm):
         data = super(AddToCartForm, self).clean()
         if 'quantity' in data:
             qty = data['quantity']
-            add_result = self.cart.add_item(self.get_variant(), qty, dry_run=True)
+            add_result = self._verify_quantity(qty)
             if add_result.quantity_delta < qty:
                 raise forms.ValidationError(add_result.reason)
         return data
+
+    def _verify_quantity(self, qty):
+        return self.cart.add_item(self.get_variant(), qty, dry_run=True)
 
     def save(self):
         return self.cart.add_item(self.get_variant(), self.cleaned_data['quantity'])


### PR DESCRIPTION
This somewhat goes hand in hand with the work I did on Carts and CartItems.  When the Order is created I need to be able to pass the additional information that I added to the CartItems to the OrderedItems too for long term persistence as the CartItems are going to be deleted at checkout.  

To achieve this I refactored the OrderedItem creation mechanism so it's now based of a specified OrderedItem subclass and additionally exists in an overloadable function so the entire of OrderManager.get_from_cart doesn't need to be overidden.

Also refactored the clean method of AddToCartForm very slightly so that the call to Cart.add_item can now be overridden to accept additional params based on the updated I made in my previous pull request.  
