### PR TITLE
Stripe integration via contrib.payment.stripe_provider

### DIFF
--- a/satchless/contrib/payment/stripe_provider/forms.py
+++ b/satchless/contrib/payment/stripe_provider/forms.py
@@ -1,0 +1,46 @@
+from django import forms
+from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.utils.translation import ugettext_lazy as _
+
+from . import models
+from ....payment import PaymentFailure
+
+import stripe
+
+class PaymentForm(forms.ModelForm):
+    stripe_customer_id = forms.CharField(max_length=50, required=False,
+                                         label=_('Stripe Customer ID'))
+    stripe_card_id = forms.CharField(max_length=50, required=False,
+                                     label=_('Stripe Card ID'))
+
+    class Meta:
+        model = models.StripeVariant
+        fields = ('stripe_customer_id', 'stripe_card_id',)
+
+    def clean(self):
+        if not self.cleaned_data.get('stripe_customer_id') \
+           and not self.cleaned_data.get('stripe_card_id'):
+            raise ValidationError(_("Either a Card or a Customer is required"))
+        return super(PaymentForm, self).clean()
+
+    def save(self, commit=True):
+        stripe.api_key = settings.STRIPE_SECRET_KEY
+        stripe_card_id = self.cleaned_data.get('stripe_card_id')
+        if stripe_card_id:
+            orderer_email = self.instance.order.user.email
+            try:
+                customer = stripe.Customer.create(
+                    card=stripe_card_id,
+                    description=orderer_email,
+                    email=orderer_email
+                )
+                self.instance.stripe_customer_id = customer.id
+            except stripe.StripeError:
+                raise PaymentFailure(_("Payment denied or network error"))
+        return super(PaymentForm, self).save(commit)
+
+class StripeReceiptForm(forms.ModelForm):
+    class Meta:
+        model = models.StripeReceipt
+

--- a/satchless/contrib/payment/stripe_provider/models.py
+++ b/satchless/contrib/payment/stripe_provider/models.py
@@ -1,0 +1,34 @@
+from ....payment.models import PaymentVariant
+from django.db import models
+
+class StripeReceipt(models.Model):
+    """
+    Removed all validation as we want to log whatever we get back from Stripe
+    no matter how mis-formed or broken.
+    """
+    # when making a card charge
+    description = models.TextField(blank=True, null=True)
+
+    # when making a customer charge
+    customer = models.CharField(max_length=50, blank=True, null=True)
+
+    fee = models.IntegerField(blank=True, null=True)
+    created = models.DateTimeField(blank=True, null=True) # starts as timestamp
+    refunded = models.NullBooleanField(blank=True, null=True)
+    livemode = models.NullBooleanField(blank=True, null=True)
+    currency = models.CharField(max_length=5, blank=True, null=True) # usd
+    amount = models.IntegerField(blank=True, null=True) # in cents
+    paid = models.NullBooleanField(blank=True, null=True)
+    token = models.CharField(max_length=50, blank=True, null=True) # "id"
+    country = models.CharField(max_length=5, blank=True, null=True)
+    cvc_check = models.CharField(max_length=5, blank=True, null=True)
+    exp_month = models.IntegerField(blank=True, null=True)
+    exp_year = models.IntegerField(blank=True, null=True)
+    last4 = models.CharField(max_length=4, blank=True, null=True)
+    card_type = models.CharField(max_length=50, blank=True, null=True) # "type"
+
+class StripeVariant(PaymentVariant):
+    stripe_customer_id = models.CharField(max_length=50, blank=True, null=True)
+    stripe_card_id = models.CharField(max_length=50, blank=True, null=True)
+    receipt = models.ForeignKey(StripeReceipt, blank=True, null=True)
+

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,9 @@ EXTRAS = {
     'mamona payment provider': [
         'mamona',
     ],
+    'stripe payment provider': [
+        'stripe',
+    ],
 }
 
 setup(name='satchless',


### PR DESCRIPTION
This pull request is a Payment Provider for stripe.com, a US credit card processing service appealing to startups because their JS API allows you to avoid handling credit card data entirely, relieving a lot of PCI compliance pressure.

The work is based off the Authorize.net contrib module and accepts either a Card or Customer token. The Card tokens are one-time-use and, internally to stripe_provider, are used to get a Customer token which is then used for payment processing. A Customer token can then be re-used in the future to process subsequent payments. PaymentForm accepts either a Customer or Card token, and will prefer the Customer token if both are provided.

This commit has NOT been refactored to work with the refactoring of December 8, 2011. This code has successfully processed test payments to Stripe but is not in regular production use. I'd like to provide tests and example code of how to use stripe_provider in the context of retrieving a Card token from Stripe via JS and then saving a stripe_provider PaymentForm, but time does not permit that at the moment.

Thank you in advance for any questions or comments -

Dan
