### PR TITLE
increase image column max_length to 255, up from 100

### DIFF
--- a/satchless/image/models.py
+++ b/satchless/image/models.py
@@ -32,7 +32,8 @@ def image_upload_to(instance, filename, **kwargs):
 
 class Image(models.Model):
     image = models.ImageField(upload_to=image_upload_to,
-            height_field='height', width_field='width')
+            height_field='height', width_field='width',
+            max_length=255)
     height = models.PositiveIntegerField(default=0, editable=False)
     width = models.PositiveIntegerField(default=0, editable=False)
 


### PR DESCRIPTION
Because of the md5 hash prefix, the remaining characters allowed until the data is truncated by the database is too low.  This is especially true in SEO driven sites where long, detailed image names are preferred.

The default django max_length for image fields ( 100 chars ) is too low.  I propose increasing it to 255 chars.

I also have south migrations, but I don't think they would be very useful at this time.
