### PR TITLE
Fix Order and Cart totals in default templates

### DIFF
--- a/examples/demo/templates/satchless/checkout/snippets/order_preview.html
+++ b/examples/demo/templates/satchless/checkout/snippets/order_preview.html
@@ -69,7 +69,7 @@
             {% endif %}
             <tr>
                 <td class="product-price" colspan="5">
-                    <span class="fullprice">{{ group.total|gross|floatformat:2 }}</span>
+                    <span class="fullprice">{{ group.get_total|gross|floatformat:2 }}</span>
                     <span class="currency">{{ order.currency }}</span><br />
                 </td>
             </tr>

--- a/examples/demo/templates/satchless/checkout/snippets/order_view.html
+++ b/examples/demo/templates/satchless/checkout/snippets/order_view.html
@@ -53,14 +53,14 @@
         {% endif %}
         <tr>
             <td class="product-price" colspan="5">
-                <span class="fullprice">{{ group.total|gross|floatformat:2 }}</span>
+                <span class="fullprice">{{ group.get_total|gross|floatformat:2 }}</span>
                 <span class="currency">{{ order.currency }}</span><br />
             </td>
         </tr>
     </tfoot>
 </table>
 {% endfor %}
-<p>Total amount to pay: {{ order.total|gross|floatformat:2 }} <span class="currency">{{ order.currency }}</span></p>
+<p>Total amount to pay: {{ order.get_total|gross|floatformat:2 }} <span class="currency">{{ order.currency }}</span></p>
 {% if order.paymentvariant %}
 <p>{% trans "Payment method" %}: {{ order.paymentvariant.get_subtype_instance }}
 {% endif %}

--- a/satchless/cart/templates/satchless/cart/view.html
+++ b/satchless/cart/templates/satchless/cart/view.html
@@ -79,12 +79,12 @@
             <tr class="total">
                 <th colspan="4" rowspan="2">{% trans "Total" %}:</th>
                 <td class="numerical">
-                    {{ cart.total|gross|floatformat:2 }} <span class="currency">{{ cart.currency }}</span><br />
+                    {{ cart.get_total|gross|floatformat:2 }} <span class="currency">{{ cart.currency }}</span><br />
                 </td>
                 <td colspan="2" rowspan="2"></td>
             </tr>
             <tr>
-                <td class="numerical netPrice">{{ cart.total|net|floatformat:2 }} <span class="currency">{{ cart.currency }}</span></td>
+                <td class="numerical netPrice">{{ cart.get_total|net|floatformat:2 }} <span class="currency">{{ cart.currency }}</span></td>
             </tr>
         </tfoot>
     </table>

--- a/satchless/cart/templates/satchless/cart/view_ajax.html
+++ b/satchless/cart/templates/satchless/cart/view_ajax.html
@@ -72,12 +72,12 @@
             <tr class="total">
                 <th colspan="4" rowspan="2">{% trans "Total" %}:</th>
                 <td class="numerical">
-                    {{ cart.total|gross|floatformat:2 }} <span class="currency">{{ cart.currency }}</span><br />
+                    {{ cart.get_total|gross|floatformat:2 }} <span class="currency">{{ cart.currency }}</span><br />
                 </td>
                 <td colspan="2" rowspan="2"></td>
             </tr>
             <tr>
-                <td class="numerical netPrice">{{ cart.total|net|floatformat:2 }} <span class="currency">{{ cart.currency }}</span></td>
+                <td class="numerical netPrice">{{ cart.get_total|net|floatformat:2 }} <span class="currency">{{ cart.currency }}</span></td>
             </tr>
         </tfoot>
     </table>

--- a/satchless/contrib/checkout/multistep/tests/templates/satchless/cart/view.html
+++ b/satchless/contrib/checkout/multistep/tests/templates/satchless/cart/view.html
@@ -71,12 +71,12 @@
             <tr class="total">
                 <th colspan="4" rowspan="2">{% trans "Total" %}:</th>
                 <td class="numerical">
-                    {{ cart.total|gross|floatformat:2 }} <span class="currency">{{ cart.currency }}</span><br />
+                    {{ cart.get_total|gross|floatformat:2 }} <span class="currency">{{ cart.currency }}</span><br />
                 </td>
                 <td colspan="2" rowspan="2"></td>
             </tr>
             <tr>
-                <td class="numerical netPrice">{{ cart.total|net|floatformat:2 }} <span class="currency">{{ cart.currency }}</span></td>
+                <td class="numerical netPrice">{{ cart.get_total|net|floatformat:2 }} <span class="currency">{{ cart.currency }}</span></td>
             </tr>
         </tfoot>
     </table>

--- a/satchless/order/templates/satchless/order/list.html
+++ b/satchless/order/templates/satchless/order/list.html
@@ -18,7 +18,7 @@
             <td><a href="{{ order_url }}">{{ order.pk }}</a></td>
             <td>{{ order.created|date }} {{ order.created|time }}</td>
             <td>{{ order.get_status_display }}</td>
-            <td>{{ order.total|floatformat:2 }} <span class="currency">{{ order.currency }}</span></td>
+            <td>{{ order.get_total|floatformat:2 }} <span class="currency">{{ order.currency }}</span></td>
         </tr>
         {% endfor %}
     </tbody>

--- a/satchless/order/templates/satchless/order/snippets/order_view.html
+++ b/satchless/order/templates/satchless/order/snippets/order_view.html
@@ -27,7 +27,7 @@
         {% endwith %}{% endif %}
         <tr>
             <th class="numerical" colspan="3">{% trans "Total" %}:</th>
-            <td class="numerical">{{ group.total|gross|floatformat:2 }} <span class="currency">{{ order.currency }}</span></td>
+            <td class="numerical">{{ group.get_total|gross|floatformat:2 }} <span class="currency">{{ order.currency }}</span></td>
         </tr>
     </tfoot>
     <tbody>
@@ -51,7 +51,7 @@
     </tbody>
 </table>
 {% endfor %}
-<p>Total amount to pay: {{ order.total|gross|floatformat:2 }} <span class="currency">{{ order.currency }}</span></p>
+<p>Total amount to pay: {{ order.get_total|gross|floatformat:2 }} <span class="currency">{{ order.currency }}</span></p>
 {% if order.paymentvariant %}
 <p>{% trans "Payment method" %}: {{ order.paymentvariant.get_subtype_instance }}
 {% endif %}


### PR DESCRIPTION
The method to get the price totals from the Cart and Order models was changed. This just adds the correct method name to the templates.
