### PR TITLE
Fixed circular import between categories and products

### DIFF
--- a/examples/demo/products/admin.py
+++ b/examples/demo/products/admin.py
@@ -11,8 +11,6 @@ import pricing.models
 from . import widgets
 from . import models
 
-from categories.admin.fields import CategoryMultipleChoiceField
-
 
 class TranslationInline(admin.StackedInline):
     extra = 1
@@ -25,6 +23,7 @@ class ImageInline(admin.TabularInline):
     }
 
 
+from categories.admin.fields import CategoryMultipleChoiceField # To prevent circular imports
 class ProductForm(forms.ModelForm):
     categories = CategoryMultipleChoiceField(required=False,
                                              queryset=product_app.Category.objects


### PR DESCRIPTION
Not exactly sure why, but when I was debugging an app I based on the demo, I kept getting circular imports with the Category fields module. Moving the import to immediately before the call seemed to fix this. I think that the demo categories app is trying to get ImageInline from the products app, and the circular import happens because the products app is calling the categories and so on…
