### PR TITLE
Enabling the StopPropagation Exception on the PricingQueue

### DIFF
--- a/satchless/pricing/handler.py
+++ b/satchless/pricing/handler.py
@@ -2,25 +2,31 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from satchless.core.handler import QueueHandler
 
-from . import PricingHandler
+from . import PricingHandler, StopPropagation
 
 
 class PricingQueue(PricingHandler, QueueHandler):
     def get_variant_price(self, variant, currency=None, price=None, quantity=1, **context):
         for handler in self.queue:
-            price = handler.get_variant_price(variant=variant,
-                                              currency=currency,
-                                              quantity=quantity,
-                                              price=price,
-                                              **context)
+            try:
+                price = handler.get_variant_price(variant=variant,
+                                                  currency=currency,
+                                                  quantity=quantity,
+                                                  price=price,
+                                                  **context)
+            except StopPropagation:
+                break
         return price
 
     def get_product_price_range(self, product, currency=None, price_range=None, **context):
         for handler in self.queue:
-            price_range = handler.get_product_price_range(product=product,
-                                                      currency=currency,
-                                                      price_range=price_range,
-                                                      **context)
+            try:
+                price_range = handler.get_product_price_range(product=product,
+                                                          currency=currency,
+                                                          price_range=price_range,
+                                                          **context)
+            except StopPropagation:
+                break
         return price_range
 
 


### PR DESCRIPTION
The StopPropagation Exception exists, but is not used or captured anywhere. I have added the try/except blocks on PricingQueue Class, now, if a price handler want to be the last price modifier can raise the StopPropagation.
