### PR TITLE
Pricing handlers api

### DIFF
--- a/satchless/pricing/__init__.py
+++ b/satchless/pricing/__init__.py
@@ -166,7 +166,7 @@ class PricingHandler(object):
     def get_product_price_range(self, product, currency, **kwargs):
         raise NotImplementedError()
 
-    def get_items_prices(self, items):
+    def get_items_prices(self, items, **kwargs):
         '''
         DO NOT OVERRIDE THIS METHOD unless you know exactly what you are doing!
 
@@ -181,7 +181,7 @@ class PricingHandler(object):
         products or their quantity.
         '''
         try:
-            updated_prices = self.compute_new_prices(items)
+            updated_prices = self._compute_prices(items, **kwargs)
         except NotImplemented:
             return items
         assert len(updated_prices) == len(items), \
@@ -190,7 +190,7 @@ class PricingHandler(object):
                 for ((variant, cnt, _), price)
                 in zip(items, updated_prices)]
 
-    def compute_new_prices(self, items):
+    def _compute_prices(self, items, **kwargs):
         '''
         This is method for updating prices in item collection.
 

--- a/satchless/pricing/handler.py
+++ b/satchless/pricing/handler.py
@@ -4,7 +4,8 @@ from . import PricingHandler
 
 
 class PricingQueue(PricingHandler, QueueHandler):
-    def get_variant_price(self, variant, currency=None, price=None, quantity=1, **context):
+    def get_variant_price(self, variant, currency=None, price=None, quantity=1,
+                          **context):
         for handler in self.queue:
             price = handler.get_variant_price(variant=variant,
                                               currency=currency,
@@ -13,7 +14,8 @@ class PricingQueue(PricingHandler, QueueHandler):
                                               **context)
         return price
 
-    def get_product_price_range(self, product, currency=None, price_range=None, **context):
+    def get_product_price_range(self, product, currency=None, price_range=None,
+                                **context):
         for handler in self.queue:
             price_range = handler.get_product_price_range(product=product,
                                                       currency=currency,
@@ -26,7 +28,7 @@ class PricingQueue(PricingHandler, QueueHandler):
     def get_items_prices(self, items, currency=None, **context):
         for handler in self.queue:
             items = handler.get_items_prices(items=items,
-                currency=currency)
+                currency=currency, **context)
         return items
 
 


### PR DESCRIPTION
satchless.pricing.PricingHandler gets two api methods:

get_items_prices - this is meant as method of getting list of tuples (variant, quantity, price) from list with the same signature. As bonus it makes sure resulting list is the same as as input list with only price elements changed. Meant for usage outside of handlers.

compute_new_prices - this is method that takes the same list of tuples (variant, quantity, price) and returns list of new prices with order preserved. This one is meant to be overridden in custom handlers.
