### PR TITLE
Fix to get Stripe Provider working

### DIFF
--- a/satchless/contrib/payment/stripe_provider/__init__.py
+++ b/satchless/contrib/payment/stripe_provider/__init__.py
@@ -31,7 +31,7 @@ class StripeProvider(PaymentProvider):
 
     def confirm(self, order, typ=None):
         v = order.receipt
-        stripe.api_key = settings.STRIPE_SECRET_KEY
+        stripe.api_key = settings.STRIPE_SECRET
         amount = int(order.get_total().net * 100)   # in cents, Stripe only does USD
         try:
             if v.stripe_card_id and not v.stripe_customer_id:
@@ -58,7 +58,7 @@ class StripeProvider(PaymentProvider):
         data = {}
         try:
             data = charge.__dict__
-            data['token'] = data['id']
+            data['stripe_charge_id'] = data['id']
             data.update(data['card'].__dict__)
             data['card_type'] = data['type']
             # Stripe response has creation time as unix timestamp

--- a/satchless/contrib/payment/stripe_provider/forms.py
+++ b/satchless/contrib/payment/stripe_provider/forms.py
@@ -25,7 +25,7 @@ class StripeReceiptForm(forms.ModelForm):
         return super(StripeReceiptForm, self).clean()
 
     def save(self, commit=True):
-        stripe.api_key = settings.STRIPE_SECRET_KEY
+        stripe.api_key = settings.STRIPE_SECRET
         stripe_card_id = self.cleaned_data.get('stripe_card_id')
         if stripe_card_id and not self.cleaned_data.get('stripe_customer_id'):
             orderer_email = self.instance.order.user.email

--- a/satchless/contrib/payment/stripe_provider/models.py
+++ b/satchless/contrib/payment/stripe_provider/models.py
@@ -6,29 +6,26 @@ class StripeReceipt(models.Model):
     Removed all validation as we want to log whatever we get back from Stripe
     no matter how mis-formed or broken.
     """
-    stripe_customer_id = models.CharField(max_length=50, blank=True, null=True)
-    stripe_card_id = models.CharField(max_length=50, blank=True, null=True)
+    stripe_customer_id = models.CharField(max_length=50, blank=True)
+    stripe_card_id = models.CharField(max_length=50, blank=True)
+    stripe_charge_id = models.CharField(max_length=50, blank=True)
 
     # when making a card charge
-    description = models.TextField(blank=True, null=True)
-
-    # when making a customer charge
-    customer = models.CharField(max_length=50, blank=True, null=True)
+    description = models.TextField(blank=True)
 
     fee = models.IntegerField(blank=True, null=True)
     created = models.DateTimeField(blank=True, null=True)   # starts as timestamp
     refunded = models.NullBooleanField(blank=True, null=True)
     livemode = models.NullBooleanField(blank=True, null=True)
-    currency = models.CharField(max_length=5, blank=True, null=True)    # usd
+    currency = models.CharField(max_length=5, blank=True)    # usd
     amount = models.IntegerField(blank=True, null=True)     # in cents
     paid = models.NullBooleanField(blank=True, null=True)
-    token = models.CharField(max_length=50, blank=True, null=True)  # "id"
-    country = models.CharField(max_length=5, blank=True, null=True)
-    cvc_check = models.CharField(max_length=5, blank=True, null=True)
+    country = models.CharField(max_length=5, blank=True)
+    cvc_check = models.CharField(max_length=5, blank=True)
     exp_month = models.IntegerField(blank=True, null=True)
     exp_year = models.IntegerField(blank=True, null=True)
-    last4 = models.CharField(max_length=4, blank=True, null=True)
-    card_type = models.CharField(max_length=50, blank=True, null=True)  # "type"
+    last4 = models.CharField(max_length=4, blank=True)
+    card_type = models.CharField(max_length=50, blank=True)  # "type"
 
     class Meta:
         abstract = True


### PR DESCRIPTION
This is just enough to get the contrib Stripe payment provider working again, as it was missed during recent Satchless refactors. To use, write your own provider and receipt classes. Subclass `StripeProvider`, providing a `payment_class`. Subclass `StripeReceipt`, providing an `order`. eg:

``` python
# mypayments/__init__.py

from satchless.contrib.payment.stripe_provider import StripeProvider
from . import models

class PaymentsProvider(StripeProvider):
    payment_class = models.Receipt


# mypayments/models.py

from django.db import models
from satchless.contrib.payment.stripe_provider.models import StripeReceipt
from ..orders.app import order_app

class Receipt(StripeReceipt):
    order = models.OneToOneField(order_app.Order, related_name='receipt')

```
