### PR TITLE
Fix variable name error

### DIFF
--- a/doc/item.rst
+++ b/doc/item.rst
@@ -295,7 +295,7 @@ A more advanced example could split an imaginary cart object into groups of obje
                    remaining.append(it)
            if digital:
                yield ItemList(digital)
-           if the_rest:
+           if remaining:
                yield ItemList(remaining)
 
 


### PR DESCRIPTION
There seems to be an historical variable name in the code. This pull request should fix it up :-)
